### PR TITLE
Fixed #1 - Boolean parameters should be represented as strings.

### DIFF
--- a/src/Picnik/Requests/AbstractRequest.php
+++ b/src/Picnik/Requests/AbstractRequest.php
@@ -51,6 +51,8 @@ abstract class AbstractRequest
 	 */
 	public function setParameter($key, $value)
 	{
+		if (is_bool($value)) $value = ($value ? 'true' : 'false');
+
 		$this->parameters[$key] = $value;
 	}
 

--- a/src/Picnik/Requests/Word/AbstractWordRequest.php
+++ b/src/Picnik/Requests/Word/AbstractWordRequest.php
@@ -55,7 +55,7 @@ abstract class AbstractWordRequest extends AbstractRequest
 	 */
 	public function useCanonical($use = true)
 	{
-		$this->setParameter('useCanonical', ($use ? 'true' : 'false'));
+		$this->setParameter('useCanonical', ($use ? true : false));
 		return $this;
 	}
 

--- a/tests/Picnik/Requests/Word/DefinitionsRequestTest.php
+++ b/tests/Picnik/Requests/Word/DefinitionsRequestTest.php
@@ -63,7 +63,7 @@ class DefinitionsRequestTest extends TestCase
 		$r = $this->getRequestInstance('foobar');
 		$r->includeRelated(true);
 
-		$this->assertSame(true, $r->getParameters()['includeRelated']);
+		$this->assertSame('true', $r->getParameters()['includeRelated']);
 	}
 
 	public function testSourceDictionariesParameterWithString()
@@ -95,7 +95,7 @@ class DefinitionsRequestTest extends TestCase
 		$r = $this->getRequestInstance('foobar');
 		$r->includeTags(true);
 
-		$this->assertSame(true, $r->getParameters()['includeTags']);
+		$this->assertSame('true', $r->getParameters()['includeTags']);
 	}
 	
 }

--- a/tests/Picnik/Requests/Word/WordRequestTest.php
+++ b/tests/Picnik/Requests/Word/WordRequestTest.php
@@ -24,7 +24,7 @@ class WordRequestTest extends TestCase
 		$r = $this->getRequestInstance('foobar');
 		$r->includeSuggestions();
 
-		$this->assertTrue($r->getParameters()['includeSuggestions']);
+		$this->assertSame('true', $r->getParameters()['includeSuggestions']);
 	}
 
 	public function testIncludingSuggestionsWithFalseParameter()
@@ -32,7 +32,7 @@ class WordRequestTest extends TestCase
 		$r = $this->getRequestInstance('foobar');
 		$r->includeSuggestions(false);
 
-		$this->assertFalse($r->getParameters()['includeSuggestions']);
+		$this->assertSame('false', $r->getParameters()['includeSuggestions']);
 	}
 
 	public function testIncludingSuggestionsWithNoneBooleanParameter()


### PR DESCRIPTION
The Wordnik API expects boolean parameters such as `useCanonical` to be expressed in the request as strings (i.e. `true` or `false`) rather than their integer counterparts.

This PR aims to resolve that issue and in turn, fix issue #1 which was caused by said parent issue.
