### PR TITLE
Closes #8 and adds vendor caching for Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ php:
   - "5.6"
   - "5.5"
   - "5.4"
-install: composer install
+install: composer install --prefer-source --no-interaction
+cache:
+  directories:
+    - vendor

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1813c38712a22936399089922a7ed1ca",
+    "hash": "8499007ef05c2fe01f63e44682443c33",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -182,16 +182,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "0.9.2",
+            "version": "0.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/padraic/mockery.git",
-                "reference": "95a4855380dc70176c51807c678fb3bd6198529a"
+                "reference": "686f85fa5b3b079cc0157d7cd3e9adb97f0b41e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/95a4855380dc70176c51807c678fb3bd6198529a",
-                "reference": "95a4855380dc70176c51807c678fb3bd6198529a",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/686f85fa5b3b079cc0157d7cd3e9adb97f0b41e1",
+                "reference": "686f85fa5b3b079cc0157d7cd3e9adb97f0b41e1",
                 "shasum": ""
             },
             "require": {
@@ -244,20 +244,20 @@
                 "test double",
                 "testing"
             ],
-            "time": "2014-09-03 10:11:10"
+            "time": "2014-12-22 10:06:19"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.0.13",
+            "version": "2.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "0e7d2eec5554f869fa7a4ec2d21e4b37af943ea5"
+                "reference": "ca158276c1200cc27f5409a5e338486bc0b4fc94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/0e7d2eec5554f869fa7a4ec2d21e4b37af943ea5",
-                "reference": "0e7d2eec5554f869fa7a4ec2d21e4b37af943ea5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca158276c1200cc27f5409a5e338486bc0b4fc94",
+                "reference": "ca158276c1200cc27f5409a5e338486bc0b4fc94",
                 "shasum": ""
             },
             "require": {
@@ -309,7 +309,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-12-03 06:41:44"
+            "time": "2014-12-26 13:28:33"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -495,16 +495,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.4.0",
+            "version": "4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bbe7bcb83b6ec1a9eaabbe1b70d4795027c53ee0"
+                "reference": "6a5e49a86ce5e33b8d0657abe145057fc513543a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bbe7bcb83b6ec1a9eaabbe1b70d4795027c53ee0",
-                "reference": "bbe7bcb83b6ec1a9eaabbe1b70d4795027c53ee0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6a5e49a86ce5e33b8d0657abe145057fc513543a",
+                "reference": "6a5e49a86ce5e33b8d0657abe145057fc513543a",
                 "shasum": ""
             },
             "require": {
@@ -562,7 +562,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-12-05 06:49:03"
+            "time": "2014-12-28 07:57:05"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -903,16 +903,16 @@
         },
         {
             "name": "sebastian/version",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43"
+                "reference": "a77d9123f8e809db3fbdea15038c27a95da4058b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43",
-                "reference": "b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/a77d9123f8e809db3fbdea15038c27a95da4058b",
+                "reference": "a77d9123f8e809db3fbdea15038c27a95da4058b",
                 "shasum": ""
             },
             "type": "library",
@@ -934,7 +934,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2014-03-07 15:35:33"
+            "time": "2014-12-15 14:25:24"
         },
         {
             "name": "symfony/yaml",
@@ -988,6 +988,7 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.4"
     },

--- a/src/Picnik/Requests/Word/HyphenationRequest.php
+++ b/src/Picnik/Requests/Word/HyphenationRequest.php
@@ -1,0 +1,46 @@
+<?php namespace Picnik\Requests\Word;
+
+use Picnik\Client;
+use Picnik\Requests\LimitableInterface;
+use Picnik\Requests\LimitTrait;
+
+/**
+ * @author Alan Ly <hello@alan.ly>
+ */
+class HyphenationRequest extends AbstractWordRequest implements LimitableInterface
+{
+
+	use LimitTrait;
+
+	const API_METHOD = 'hyphenation';
+
+	/**
+	 * The dictionary to retrieve the hyphenation from. Please refer to the API
+	 * documentation for further details concerning available options. This method
+	 * is chainable.
+	 * @param  string  $dictionary the source dictionary to use
+	 * @return HyphenationRequest
+	 */
+	public function sourceDictionary($dictionary = null)
+	{
+		if (! $dictionary) return $this;
+
+		$this->setParameter('sourceDictionary', $dictionary);
+		return $this;
+	}
+
+	/**
+	 * Generates the request target URL based on the requested word.
+	 * @return string
+	 */
+	public function generateRequestTarget()
+	{
+		$endpoint = Client::API_ENDPOINT;
+		$baseMethod = WordRequest::API_METHOD;
+		$format = Client::RESPONSE_FORMAT;
+		$method = HyphenationRequest::API_METHOD;
+
+		return "{$endpoint}/{$baseMethod}.{$format}/{$this->word}/{$method}";
+	}
+	
+}

--- a/tests/Picnik/Requests/Word/HyphenationRequestTest.php
+++ b/tests/Picnik/Requests/Word/HyphenationRequestTest.php
@@ -1,0 +1,76 @@
+<?php namespace Picnik\Requests\Word;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Message\Response as GuzzleResponse;
+use GuzzleHttp\Subscriber\History as GuzzleHistory;
+use GuzzleHttp\Subscriber\Mock as GuzzleMock;
+use Picnik\TestCase;
+
+class HyphenationRequestTest extends TestCase
+{
+	
+	protected function getRequestInstance($word)
+	{
+		$c = $this->getClientMock();
+		return new HyphenationRequest($c, $word);
+	}
+
+	public function testProperRequestGenerated()
+	{
+		// Create the necessary Guzzle instances to mock the request.
+		$gc = new GuzzleClient;
+		$gh = new GuzzleHistory;
+		$gm = new GuzzleMock([new GuzzleResponse(200)]);
+
+		// Attach subscribers to the client.
+		$gc->getEmitter()->attach($gm);
+		$gc->getEmitter()->attach($gh);
+
+		$c = $this->getClientMock();
+		$c->shouldReceive('getApiKey')->andReturn('foobar');
+		$c->shouldReceive('getGuzzle')->andReturn($gc);
+
+		$r = new HyphenationRequest($c, 'foobar');
+		$r->get();
+
+		$gr = $gh->getLastRequest();
+
+		$expectedTarget = 'https://api.wordnik.com/v4/word.json/foobar/hyphenation';
+
+		$this->assertStringStartsWith($expectedTarget, $gr->getUrl());
+		$this->assertEquals($r->getParameters(), $gr->getQuery()->toArray());
+	}
+
+	public function testSourceDictionaryParameterWithValue()
+	{
+		$r = $this->getRequestInstance('foobar');
+		$r->sourceDictionary('foo');
+
+		$this->assertSame('foo', $r->getParameters()['sourceDictionary']);
+	}
+
+	public function testSourceDictionaryParameterWithNull()
+	{
+		$r = $this->getRequestInstance('foobar');
+		$r->sourceDictionary(null);
+
+		$this->assertArrayNotHasKey('sourceDictionary', $r->getParameters());
+	}
+
+	public function testLimitParameterWorks()
+	{
+		$r = $this->getRequestInstance('foobar');
+		$r->limit(7);
+
+		$this->assertSame(7, $r->getParameters()['limit']);
+	}
+
+	public function testUseCanonicalParameterWorks()
+	{
+		$r = $this->getRequestInstance('foobar');
+		$r->useCanonical(true);
+
+		$this->assertSame('true', $r->getParameters()['useCanonical']);
+	}
+
+}


### PR DESCRIPTION
This PR introduces the word:hyphenation method support for request #8 and adds the necessary Travis-CI configuration to support caching on the Composer vendor directory.

Also updates the `composer.lock` file.