### PR TITLE
Fixes #8, closes #9

### DIFF
--- a/src/Picnik/Client.php
+++ b/src/Picnik/Client.php
@@ -119,5 +119,10 @@ class Client
 	{
 		return new Requests\Word\HyphenationRequest($this, $word);
 	}
+
+	public function wordPronunciations($word)
+	{
+		return new Requests\Word\PronunciationsRequest($this, $word);
+	}
 	
 }

--- a/src/Picnik/Client.php
+++ b/src/Picnik/Client.php
@@ -108,5 +108,16 @@ class Client
 	{
 		return new Requests\Word\AudioRequest($this, $word);
 	}
+
+	/**
+	 * Create a new word:hyphenation request that allows us to retrieve the
+	 * hyphenated variant of a word from the API.
+	 * @param  string $word the word to query
+	 * @return Picnik\Requests\Word\HyphentationRequest
+	 */
+	public function wordHyphenation($word)
+	{
+		return new Requests\Word\HyphenationRequest($this, $word);
+	}
 	
 }

--- a/src/Picnik/Requests/LimitTrait.php
+++ b/src/Picnik/Requests/LimitTrait.php
@@ -7,7 +7,7 @@ trait LimitTrait
 	 * The maximum number of pronounciations that should be returned for the
 	 * request. This method is chainable.
 	 * @param  int $count the number of results this request should be limited to
-	 * @return mixed
+	 * @return AbstractRequest
 	 */
 	public function limit($count)
 	{

--- a/src/Picnik/Requests/LimitTrait.php
+++ b/src/Picnik/Requests/LimitTrait.php
@@ -1,6 +1,7 @@
 <?php namespace Picnik\Requests;
 
-trait LimitTrait {
+trait LimitTrait
+{
 
 	/**
 	 * The maximum number of pronounciations that should be returned for the

--- a/src/Picnik/Requests/LimitableInterface.php
+++ b/src/Picnik/Requests/LimitableInterface.php
@@ -7,7 +7,7 @@ interface LimitableInterface
 	 * The maximum number of pronounciations that should be returned for the
 	 * request. This method is chainable.
 	 * @param  int $count the number of results this request should be limited to
-	 * @return mixed
+	 * @return AbstractRequest
 	 */
 	public function limit($count);
 	

--- a/src/Picnik/Requests/LimitableInterface.php
+++ b/src/Picnik/Requests/LimitableInterface.php
@@ -1,6 +1,7 @@
 <?php namespace Picnik\Requests;
 
-interface LimitableInterface {
+interface LimitableInterface
+{
 
 	/**
 	 * The maximum number of pronounciations that should be returned for the

--- a/src/Picnik/Requests/SourceDictionaryInterface.php
+++ b/src/Picnik/Requests/SourceDictionaryInterface.php
@@ -1,0 +1,15 @@
+<?php namespace Picnik\Requests;
+
+interface SourceDictionaryInterface
+{
+
+	/**
+	 * The dictionary to use as the source for the request. Please refer to the
+	 * API documentation in order to see the available options. This method is 
+	 * chainable.
+	 * @param  string  $dictionary the source dictionary to use
+	 * @return AbstractRequest
+	 */
+	public function sourceDictionary($dictionary);
+
+}

--- a/src/Picnik/Requests/SourceDictionaryTrait.php
+++ b/src/Picnik/Requests/SourceDictionaryTrait.php
@@ -1,0 +1,21 @@
+<?php namespace Picnik\Requests;
+
+trait SourceDictionaryTrait
+{
+
+	/**
+	 * The dictionary to use as the source for the request. Please refer to the
+	 * API documentation in order to see the available options. This method is 
+	 * chainable.
+	 * @param  string  $dictionary the source dictionary to use
+	 * @return AbstractRequest
+	 */
+	public function sourceDictionary($dictionary)
+	{
+		if (! $dictionary) return $this;
+
+		$this->setParameter('sourceDictionary', $dictionary);
+		return $this;
+	}
+	
+}

--- a/src/Picnik/Requests/Word/HyphenationRequest.php
+++ b/src/Picnik/Requests/Word/HyphenationRequest.php
@@ -3,31 +3,21 @@
 use Picnik\Client;
 use Picnik\Requests\LimitableInterface;
 use Picnik\Requests\LimitTrait;
+use Picnik\Requests\SourceDictionaryInterface;
+use Picnik\Requests\SourceDictionaryTrait;
 
 /**
  * @author Alan Ly <hello@alan.ly>
  */
-class HyphenationRequest extends AbstractWordRequest implements LimitableInterface
+class HyphenationRequest
+	extends AbstractWordRequest
+	implements LimitableInterface, SourceDictionaryInterface
 {
 
 	use LimitTrait;
+	use SourceDictionaryTrait;
 
 	const API_METHOD = 'hyphenation';
-
-	/**
-	 * The dictionary to retrieve the hyphenation from. Please refer to the API
-	 * documentation for further details concerning available options. This method
-	 * is chainable.
-	 * @param  string  $dictionary the source dictionary to use
-	 * @return HyphenationRequest
-	 */
-	public function sourceDictionary($dictionary = null)
-	{
-		if (! $dictionary) return $this;
-
-		$this->setParameter('sourceDictionary', $dictionary);
-		return $this;
-	}
 
 	/**
 	 * Generates the request target URL based on the requested word.

--- a/src/Picnik/Requests/Word/HyphenationRequest.php
+++ b/src/Picnik/Requests/Word/HyphenationRequest.php
@@ -14,8 +14,7 @@ class HyphenationRequest
 	implements LimitableInterface, SourceDictionaryInterface
 {
 
-	use LimitTrait;
-	use SourceDictionaryTrait;
+	use LimitTrait, SourceDictionaryTrait;
 
 	const API_METHOD = 'hyphenation';
 

--- a/src/Picnik/Requests/Word/PronunciationsRequest.php
+++ b/src/Picnik/Requests/Word/PronunciationsRequest.php
@@ -1,0 +1,46 @@
+<?php namespace Picnik\Requests\Word;
+
+use Picnik\Client;
+use Picnik\Requests\LimitableInterface;
+use Picnik\Requests\LimitTrait;
+use Picnik\Requests\SourceDictionaryInterface;
+use Picnik\Requests\SourceDictionaryTrait;
+
+class PronunciationsRequest
+	extends AbstractWordRequest
+	implements LimitableInterface, SourceDictionaryInterface
+{
+
+	use LimitTrait, SourceDictionaryTrait;
+
+	const API_METHOD = 'pronunciations';
+
+	/**
+	 * Determines the pronunciation format that should be returned for this
+	 * request. Please refer to the API documentation in order to determine the
+	 * possible options and appropriate usage. This method is chainable.
+	 * @param  string  $format  the pronunciation format to use
+	 * @return PronuncationsRequest
+	 */
+	public function typeFormat($format)
+	{
+		if (! $format) return $this;
+		$this->setParameter('typeFormat', $format);
+		return $this;
+	}
+
+	/**
+	 * Generates the request target URL based on the requested word.
+	 * @return string
+	 */
+	public function generateRequestTarget()
+	{
+		$endpoint = Client::API_ENDPOINT;
+		$baseMethod = WordRequest::API_METHOD;
+		$format = Client::RESPONSE_FORMAT;
+		$method = PronunciationsRequest::API_METHOD;
+
+		return "{$endpoint}/{$baseMethod}.{$format}/{$this->word}/{$method}";
+	}
+
+}

--- a/tests/Picnik/ClientTest.php
+++ b/tests/Picnik/ClientTest.php
@@ -6,6 +6,14 @@
 class ClientTest extends TestCase
 {
 
+	protected function makeClientInstance($key = 'foobar')
+	{
+		$c = new Client;
+		$c->setApiKey($key);
+
+		return $c;
+	}
+
 	public function testSetApiInstanceKeyInSetter()
 	{
 		$c = new Client;
@@ -42,6 +50,15 @@ class ClientTest extends TestCase
 		$request = $c->wordAudio('bar');
 
 		$this->assertInstanceOf('Picnik\Requests\Word\AudioRequest', $request);
+	}
+
+	public function testHyphenationInstanceCreatedForWord()
+	{
+		$c = $this->makeClientInstance();
+
+		$r = $c->wordHyphenation('bar');
+
+		$this->assertInstanceOf('Picnik\Requests\Word\HyphenationRequest', $r);
 	}
 
 }

--- a/tests/Picnik/ClientTest.php
+++ b/tests/Picnik/ClientTest.php
@@ -61,4 +61,12 @@ class ClientTest extends TestCase
 		$this->assertInstanceOf('Picnik\Requests\Word\HyphenationRequest', $r);
 	}
 
+	public function testPronunciationsInstanceCreatedForWord()
+	{
+		$c = $this->makeClientInstance();
+		$r = $c->wordPronunciations('bar');
+
+		$this->assertInstanceOf('Picnik\Requests\Word\PronunciationsRequest', $r);
+	}
+
 }

--- a/tests/Picnik/Requests/Word/PronunciationsRequestTest.php
+++ b/tests/Picnik/Requests/Word/PronunciationsRequestTest.php
@@ -1,0 +1,84 @@
+<?php namespace Picnik\Requests\Word;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Message\Response as GuzzleResponse;
+use GuzzleHttp\Subscriber\History as GuzzleHistory;
+use GuzzleHttp\Subscriber\Mock as GuzzleMock;
+use Picnik\TestCase;
+
+class PronunciationsRequestTest extends TestCase
+{
+
+	protected function getRequestInstance($word)
+	{
+		$c = $this->getClientMock();
+		return new PronunciationsRequest($c, $word);
+	}
+
+	public function testProperRequestGenerated()
+	{
+		// Create the necessary Guzzle instances to mock the request.
+		$gc = new GuzzleClient;
+		$gh = new GuzzleHistory;
+		$gm = new GuzzleMock([new GuzzleResponse(200)]);
+
+		// Attach subscribers to the client.
+		$gc->getEmitter()->attach($gm);
+		$gc->getEmitter()->attach($gh);
+
+		$c = $this->getClientMock();
+		$c->shouldReceive('getApiKey')->andReturn('foobar');
+		$c->shouldReceive('getGuzzle')->andReturn($gc);
+
+		$r = new PronunciationsRequest($c, 'foobar');
+		$r->get();
+
+		$gr = $gh->getLastRequest();
+
+		$expectedTarget = 'https://api.wordnik.com/v4/word.json/foobar/pronunciations';
+
+		$this->assertStringStartsWith($expectedTarget, $gr->getUrl());
+		$this->assertEquals($r->getParameters(), $gr->getQuery()->toArray());
+	}
+
+	public function testSourceDictionaryParameterWithValue()
+	{
+		$r = $this->getRequestInstance('foobar');
+		$r->sourceDictionary('foo');
+
+		$this->assertSame('foo', $r->getParameters()['sourceDictionary']);
+	}
+
+	public function testSourceDictionaryParameterWithNull()
+	{
+		$r = $this->getRequestInstance('foobar');
+		$r->sourceDictionary(null);
+
+		$this->assertArrayNotHasKey('sourceDictionary', $r->getParameters());
+	}
+
+	public function testLimitParameterWorks()
+	{
+		$r = $this->getRequestInstance('foobar');
+		$r->limit(7);
+
+		$this->assertSame(7, $r->getParameters()['limit']);
+	}
+
+	public function testUseCanonicalParameterWorks()
+	{
+		$r = $this->getRequestInstance('foobar');
+		$r->useCanonical(true);
+
+		$this->assertSame('true', $r->getParameters()['useCanonical']);
+	}
+
+	public function testTypeFormatParameterWorks()
+	{
+		$r = $this->getRequestInstance('foobar');
+		$r->typeFormat('bar');
+
+		$this->assertSame('bar', $r->getParameters()['typeFormat']);
+	}
+	
+}


### PR DESCRIPTION
- Added the missing access method to the `Client` class that's required in order to make use of the word:hyphenation request.
- Implements #9, the word:pronuncations request.
- Additional fixes and updates to the code.