### PR TITLE
Implementation for related words request.

### DIFF
--- a/src/Picnik/Client.php
+++ b/src/Picnik/Client.php
@@ -130,5 +130,16 @@ class Client
 	{
 		return new Requests\Word\PronunciationsRequest($this, $word);
 	}
+
+	/**
+	 * Create a new word:relatedWords request that allows us to query for other
+	 * words that are associated with the queried word.
+	 * @param  string  $word  the associated word
+	 * @return Picnik\Requests\Word\RelatedWordsRequest
+	 */
+	public function wordRelatedWords($word)
+	{
+		return new Requests\Word\RelatedWordsRequest($this, $word);
+	}
 	
 }

--- a/src/Picnik/Client.php
+++ b/src/Picnik/Client.php
@@ -120,6 +120,12 @@ class Client
 		return new Requests\Word\HyphenationRequest($this, $word);
 	}
 
+	/**
+	 * Create a word:pronunciations request that allows us to retrieve the
+	 * pronunciation hints from the API for a specific word.
+	 * @param  string  $word  the associated word
+	 * @return Picnik\Requests\Word\PronunciationsRequest
+	 */
 	public function wordPronunciations($word)
 	{
 		return new Requests\Word\PronunciationsRequest($this, $word);

--- a/src/Picnik/Requests/Word/HyphenationRequest.php
+++ b/src/Picnik/Requests/Word/HyphenationRequest.php
@@ -22,7 +22,7 @@ class HyphenationRequest
 	 * Generates the request target URL based on the requested word.
 	 * @return string
 	 */
-	public function generateRequestTarget()
+	protected function generateRequestTarget()
 	{
 		$endpoint = Client::API_ENDPOINT;
 		$baseMethod = WordRequest::API_METHOD;

--- a/src/Picnik/Requests/Word/PronunciationsRequest.php
+++ b/src/Picnik/Requests/Word/PronunciationsRequest.php
@@ -33,7 +33,7 @@ class PronunciationsRequest
 	 * Generates the request target URL based on the requested word.
 	 * @return string
 	 */
-	public function generateRequestTarget()
+	protected function generateRequestTarget()
 	{
 		$endpoint = Client::API_ENDPOINT;
 		$baseMethod = WordRequest::API_METHOD;

--- a/src/Picnik/Requests/Word/RelatedWordsRequest.php
+++ b/src/Picnik/Requests/Word/RelatedWordsRequest.php
@@ -1,0 +1,66 @@
+<?php namespace Picnik\Requests\Word;
+
+use Picnik\Client;
+use Picnik\Requests\LimitableInterface;
+
+class RelatedWordsRequest extends AbstractWordRequest implements LimitableInterface
+{
+
+	const API_METHOD = 'relatedWords';
+
+	/**
+	 * Restrict the returned results to a particular relationship type. Please
+	 * refer to the API documentation for the available options. This method is
+	 * chainable.
+	 * @param  string  $type  the specific relationship type to fetch
+	 * @return RelatedWordsRequest
+	 */
+	public function relationshipTypes($type)
+	{
+		if (! $type) return $this;
+
+		$this->setParameter('relationshipTypes', $type);
+		return $this;
+	}
+
+	/**
+	 * Limits the number of results returned, *per* relationship type selected.
+	 * This method is chainable.
+	 * @param  int  $count  the total number of results per type selected
+	 * @return RelatedWordsRequest
+	 */
+	public function limitPerRelationshipType($count)
+	{
+		$limit = intval($count);
+		$this->setParameter('limitPerRelationshipType', $limit);
+		return $this;
+	}
+
+	/**
+	 * Limits the number of results returned, *per* relationship type selected.
+	 * This method is chainable.
+	 * @param  int  $count  the total number of results per type selected
+	 * @return RelatedWordsRequest
+	 */
+	public function limit($count)
+	{
+		return $this->limitPerRelationshipType($count);
+	}
+
+	/**
+	 * Gets the API key from the Client instance and adds it to the request
+	 * parameters. An `AuthorizationException` is thrown when the API key is
+	 * missing from the Client.
+	 * @throws  AuthorizationException  If API key is missing.
+	 */
+	protected function generateRequestTarget()
+	{
+		$endpoint = Client::API_ENDPOINT;
+		$baseMethod = WordRequest::API_METHOD;
+		$format = Client::RESPONSE_FORMAT;
+		$method = self::API_METHOD;
+
+		return "{$endpoint}/{$baseMethod}.{$format}/{$this->word}/{$method}";
+	}
+
+}

--- a/tests/Picnik/ClientTest.php
+++ b/tests/Picnik/ClientTest.php
@@ -69,4 +69,12 @@ class ClientTest extends TestCase
 		$this->assertInstanceOf('Picnik\Requests\Word\PronunciationsRequest', $r);
 	}
 
+	public function testRelatedWordsInstanceCreatedForWord()
+	{
+		$c = $this->makeClientInstance();
+		$r = $c->wordRelatedWords('bar');
+
+		$this->assertInstanceOf('Picnik\Requests\Word\RelatedWordsRequest', $r);
+	}
+
 }

--- a/tests/Picnik/Requests/Word/RelatedWordsRequestTest.php
+++ b/tests/Picnik/Requests/Word/RelatedWordsRequestTest.php
@@ -1,0 +1,88 @@
+<?php namespace Picnik\Requests\Word;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Message\Response as GuzzleResponse;
+use GuzzleHttp\Subscriber\History as GuzzleHistory;
+use GuzzleHttp\Subscriber\Mock as GuzzleMock;
+use Picnik\TestCase;
+
+class RelatedWordsRequestTest extends TestCase
+{
+
+	protected function getRequestInstance($word = 'foobar')
+	{
+		$c = $this->getClientMock();
+		return new RelatedWordsRequest($c, $word);
+	}
+
+	public function testProperRequestGenerated()
+	{
+		// Create the necessary Guzzle instances to mock the request.
+		$gc = new GuzzleClient;
+		$gh = new GuzzleHistory;
+		$gm = new GuzzleMock([new GuzzleResponse(200)]);
+
+		// Attach subscribers to the client.
+		$gc->getEmitter()->attach($gm);
+		$gc->getEmitter()->attach($gh);
+
+		$c = $this->getClientMock();
+		$c->shouldReceive('getApiKey')->andReturn('foobar');
+		$c->shouldReceive('getGuzzle')->andReturn($gc);
+
+		$r = new RelatedWordsRequest($c, 'foobar');
+		$r->get();
+
+		$gr = $gh->getLastRequest();
+
+		$expectedTarget = 'https://api.wordnik.com/v4/word.json/foobar/relatedWords';
+
+		$this->assertStringStartsWith($expectedTarget, $gr->getUrl());
+		$this->assertEquals($r->getParameters(), $gr->getQuery()->toArray());
+	}
+
+	public function testUseCanonicalWorks()
+	{
+		$r = $this->getRequestInstance();
+		$r->useCanonical(true);
+
+		$this->assertArrayHasKey('useCanonical', $r->getParameters());
+		$this->assertSame('true', $r->getParameters()['useCanonical']);
+	}
+
+	public function testRelationshipTypesWithNullDoesNotAddParameter()
+	{
+		$r = $this->getRequestInstance();
+		$r->relationshipTypes(null);
+
+		$this->assertArrayNotHasKey('relationshipTypes', $r->getParameters());
+	}
+
+	public function testRelationshipTypesWithValueAddsParameterAndValue()
+	{
+		$r = $this->getRequestInstance();
+		$r->relationshipTypes('bar');
+
+		$this->assertArrayHasKey('relationshipTypes', $r->getParameters());
+		$this->assertSame('bar', $r->getParameters()['relationshipTypes']);
+	}
+
+	public function testLimitPerRelationshipTypeMethodAddsParameter()
+	{
+		$r = $this->getRequestInstance();
+		$r->limitPerRelationshipType(7);
+
+		$this->assertArrayHasKey('limitPerRelationshipType', $r->getParameters());
+		$this->assertSame(7, $r->getParameters()['limitPerRelationshipType']);
+	}
+
+	public function testLimitableMethodWrapsLimitPerRelationshipType()
+	{
+		$r = $this->getRequestInstance();
+		$r->limit(7);
+
+		$this->assertArrayHasKey('limitPerRelationshipType', $r->getParameters());
+		$this->assertSame(7, $r->getParameters()['limitPerRelationshipType']);
+	}
+
+}


### PR DESCRIPTION
This PR closes #12, which is a feature request for retrieving the synonyms of a word. The PR outlined here implements the `relatedWords` API method, which amongst other things, allows for the retrieval of synonyms, given a word.

The specific usage is as follows:

``` php
$c = new Picnik\Client;
$c->setApiKey('foobar');

$result = $c->wordRelatedWords('alternate')->limit(1)->relationshipTypes('synonym')->get();

var_dump( $result );
```

which, when executed, gives us the output:

``` php
array(1) {                     
  [0]=>                        
  object(stdClass)#18 (2) {    
    ["relationshipType"]=>     
    string(7) "synonym"        
    ["words"]=>                
    array(1) {                 
      [0]=>                    
      string(11) "vicissitude" 
    }                          
  }                            
}                              
```
